### PR TITLE
Use project-path as current working directory, when executing "mix format"

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -25,7 +25,7 @@ export default {
   formatTextEditor(editor) {
     try {
       const { text, range } = this.currentTextSelection(editor);
-      const { status, stdout, stderr } = this.runFormat(text);
+      const { status, stdout, stderr } = this.runFormat(editor, text);
 
       switch (status) {
       case 0: {
@@ -58,11 +58,23 @@ export default {
   },
 
   // runs mix format process and returns response
-  runFormat(text) {
+  runFormat(editor, text) {
     let tmpPath = tmp.tmpNameSync();
     fs.writeFileSync(tmpPath, text);
 
-    var result = process.spawnSync(main.mixExecutable(), ["format", tmpPath]);
+    var opts = {};
+
+    if (editor.getPath) {
+      var editorPath = editor.getPath();
+      projectPath = atom.project.relativizePath(editorPath)[0];
+
+      if(typeof projectPath !== "undefined") {
+        opts = {cwd: projectPath};
+      }
+    }
+
+    var result = process.spawnSync(main.mixExecutable(), ["format", tmpPath], opts);
+
     if (result.status == 0) {
       result = {
         status: result.status,

--- a/spec/formatter-spec.js
+++ b/spec/formatter-spec.js
@@ -101,23 +101,25 @@ describe("Formatter", () => {
     });
 
     it("uses project path when mixDirectory setting undefined", () => {
+      let editor = atom.workspace.getActiveTextEditor();
       atom.config.set("atom-elixir-formatter.mixDirectory", undefined);
 
       formatter.runFormat("input text");
-      expect(process.spawnSync).toHaveBeenCalledWith("mix", [
-        "format",
-        "/tmp/file"
-      ]);
+      expect(process.spawnSync).toHaveBeenCalledWith(
+        "mix", ["format", "/tmp/file"], {}
+      );
     });
 
     it("uses mixDirectory setting when defined", () => {
+      let editor = atom.workspace.getActiveTextEditor();
       atom.config.set("atom-elixir-formatter.mixDirectory", "/tmp");
 
-      formatter.runFormat("input text");
-      expect(process.spawnSync).toHaveBeenCalledWith("mix", [
-        "format",
-        "/tmp/file"
-      ]);
+      formatter.runFormat(editor, "input text");
+      expect(process.spawnSync).toHaveBeenCalledWith(
+        "mix",
+        ["format", "/tmp/file"],
+        {cwd: path.join(__dirname, "fixtures")}
+      );
     });
   });
 });


### PR DESCRIPTION
Current working directory should be set to the editor "project path", to ensure that any local `.formatter.exs` is used during the "mix format" task execution.