### PR TITLE
Fix few issues on Windows

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -23,18 +23,15 @@ export default {
   // formats the given text editor
   formatTextEditor(editor, range = null) {
     try {
-      const { status, stdout, stderr } = this.runFormat(
+      const { status, stdout, stderr, error } = this.runFormat(
         this.getTextInRange(editor, range)
       );
 
-      switch (status) {
-      case 0: {
+      if (status == 0 && (!stderr || !stderr.length) && !error) {
         this.insertText(editor, range, stdout.toString());
-        break;
-      }
-      default:
+      } else {
         this.showErrorNotifcation("Elixir Formatter Error", {
-          detail: stderr
+          detail: stderr || error
         });
       }
     } catch (exception) {

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -53,7 +53,7 @@ export default {
 
   // runs mix format process and returns response
   runFormat(text) {
-    var opts = { input: text };
+    var opts = { input: text, shell: true };
 
     if ((projectPath = main.projectPath())) {
       opts.cwd = projectPath;

--- a/spec/formatter-spec.js
+++ b/spec/formatter-spec.js
@@ -105,7 +105,7 @@ describe("Formatter", () => {
       expect(process.spawnSync).toHaveBeenCalledWith(
         "elixir",
         ["mix", "format", "-"],
-        { input: "input text", cwd: main.projectPath() }
+        { input: "input text", shell: true, cwd: main.projectPath() }
       );
     });
 
@@ -119,7 +119,7 @@ describe("Formatter", () => {
       expect(process.spawnSync).toHaveBeenCalledWith(
         "/path/to/elixir",
         ["mix", "format", "-"],
-        { input: "input text", cwd: main.projectPath() }
+        { input: "input text", shell: true, cwd: main.projectPath() }
       );
     });
 
@@ -130,7 +130,7 @@ describe("Formatter", () => {
       expect(process.spawnSync).toHaveBeenCalledWith(
         "elixir",
         ["mix", "format", "-"],
-        { input: "input text", cwd: main.projectPath() }
+        { input: "input text", shell: true, cwd: main.projectPath() }
       );
     });
 
@@ -141,7 +141,7 @@ describe("Formatter", () => {
       expect(process.spawnSync).toHaveBeenCalledWith(
         "elixir",
         ["/path/to/mix", "format", "-"],
-        { input: "input text", cwd: main.projectPath() }
+        { input: "input text", shell: true, cwd: main.projectPath() }
       );
     });
 
@@ -151,7 +151,7 @@ describe("Formatter", () => {
       expect(process.spawnSync).toHaveBeenCalledWith(
         "elixir",
         ["mix", "format", "-"],
-        { input: "input text", cwd: main.projectPath() }
+        { input: "input text", shell: true, cwd: main.projectPath() }
       );
     });
 
@@ -162,7 +162,7 @@ describe("Formatter", () => {
       expect(process.spawnSync).toHaveBeenCalledWith(
         "elixir",
         ["mix", "format", "-"],
-        { input: "input text" }
+        { input: "input text", shell: true }
       );
     });
   });


### PR DESCRIPTION
Hi, @rgreenjr 

As I was trying to use the Elixir formatter on my Windows environment with Atom 1.21.1 and Elixir 1.6 (compiled from source), I encountered a few issues and I did some fixes...

1. The first was that on formatting an `.ex` file (either on save or by the menu) i got the "Elixir Formatter Error" without any details. I found that a similar issue was reported before (#2), I'm not usre if it is the same case, but in my case I had an error coming from Node.js.
The commit 73f18c5 fixes this issue.
2. Then, i got the error:

```
Error: spawnSync mix ENOENT
    at exports._errnoException (util.js:1022:11)
    at Object.spawnSync (child_process.js:480:20)
    at Object.runFormat (file:///C:/Users/indyone/.atom/packages/atom-elixir-formatter/lib/formatter.js:62:26)
    at Object.formatTextEditor (file:///C:/Users/indyone/.atom/packages/atom-elixir-formatter/lib/formatter.js:26:54)
    at file:///C:/Users/indyone/.atom/packages/atom-elixir-formatter/lib/main.js:37:19
    at Function.module.exports.Emitter.simpleDispatch (C:\Users\indyone\AppData\Local\atom\app-1.21.1\resources\app\node_modules\event-kit\lib\emitter.js:25:20)
    at Emitter.<anonymous> (C:\Users\indyone\AppData\Local\atom\app-1.21.1\resources\app\node_modules\event-kit\lib\emitter.js:154:50)
    at Emitter.module.exports.Emitter.emitAsync (C:\Users\indyone\AppData\Local\atom\app-1.21.1\resources\app\node_modules\event-kit\lib\emitter.js:157:18)
    at C:\Users\indyone\AppData\Local\atom\app-1.21.1\resources\app\node_modules\text-buffer\lib\text-buffer.js:1288:38
```
  The issue here is that on Windows, `child_process.spawn` ignores `PATHEXT`. According to the [documentation](https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows) you can use the `{shell: true}` option to fix that. That's my 2nd commit fe16215 

3. After fixing that, i got the error "No file named mix". I found out that the command that was running for formatting the file was `elixir mix format -`, which indeed produces this error. Your commit 35027e8c17e516027047696b523a85951926d81d does not seem to work for me, so quickly reverted it (just the offending code, no tests etc) with my commit aec32ec.

After these changes, Elixir Formatter works flawlessly! 
Please check my fixes. Thanks

*Note: Unfortunately, I haven't tested this on MacOS or Linux to see if these changes break something else.*