### PR TITLE
Enable formatter in heex files

### DIFF
--- a/lib/editor-helper.js
+++ b/lib/editor-helper.js
@@ -5,7 +5,7 @@ import settings from "./settings";
 export default {
   // returns true if editor grammar is elixir
   hasElixirGrammar(editor) {
-    return editor.getGrammar().scopeName === "source.elixir";
+    return editor.getGrammar().scopeName.endsWith(".elixir");
   },
 
   // returns true if editor should be formatted
@@ -15,5 +15,5 @@ export default {
       settings.shouldFormatOnSave() &&
       settings.isPackageEnabled()
     );
-  }
+  },
 };


### PR DESCRIPTION
Hey,

Thanks for the great package!

This change works with everything as before and can support heex.
heex has text.html.elixir for scopeName.

Could close this: https://github.com/rgreenjr/atom-elixir-formatter/issues/32

Cheers